### PR TITLE
Add cross-platform build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Build
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        goos: [linux, windows]
+        goarch: [amd64]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.22'
+      - name: Build
+        run: |
+          mkdir -p build
+          ext=""
+          if [ "${{ matrix.goos }}" = "windows" ]; then ext=".exe"; fi
+          GOOS=${{ matrix.goos }} GOARCH=${{ matrix.goarch }} go build -o build/webdebugger-${{ matrix.goos }}-${{ matrix.goarch }}$ext
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: webdebugger-${{ matrix.goos }}-${{ matrix.goarch }}
+          path: build/webdebugger-${{ matrix.goos }}-${{ matrix.goarch }}*


### PR DESCRIPTION
## Summary
- build Go binaries for Linux and Windows on each commit
- upload platform artifacts for download

## Testing
- `go build ./...`


------
https://chatgpt.com/codex/tasks/task_e_68b7d3c80f908324a90f9336f668d0a1